### PR TITLE
Implement the fix suggested by @Pizza4Ever in #52

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-mod_version = 1.1.5
+mod_version = 1.1.6
 mod_id = shrink
 maven_group = gigabit101
 

--- a/src/main/java/net/gigabit101/shrink/network/PacketShrink.java
+++ b/src/main/java/net/gigabit101/shrink/network/PacketShrink.java
@@ -54,7 +54,7 @@ public class PacketShrink
                             iShrinkProvider.deserializeNBT(message.nbt);
 
                             entity.refreshDimensions();
-                            entity.setPos(entity.blockPosition().getX(), entity.blockPosition().getY(), entity.blockPosition().getZ());
+                            entity.setPos(entity.position().x, entity.position().y, entity.position().z);
 
                             if(!(entity instanceof PlayerEntity))
                             {


### PR DESCRIPTION
Compiled and tested ingame on an enigmatica 6 0.5.17 server and it seems to work perfectly, spawned mobs don't shift 👌 

![2021-10-24_19 56 48](https://user-images.githubusercontent.com/3179271/138606653-d89e1353-11d8-4979-83b8-1bd9d0d57cda.png)

and players coming into range and/or using the shrinking device also seem to no longer yeet you to the corners of coords 🙂 